### PR TITLE
Move new FFT functions to lib_dsp

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 xCORE-200 DSP library change log
 ================================
 
+6.3.0
+-----
+
+  * ADDED: float4 FFT functions for float4 values
+  * ADDED: float FFT functions using lib_xs3_math, limited to 512 real points
+
 6.2.1
 -----
 

--- a/examples/app_fft_xs3_math/Makefile
+++ b/examples/app_fft_xs3_math/Makefile
@@ -19,7 +19,7 @@ XCC_FLAGS = $(BUILD_FLAGS)
 APP_NAME = app
 
 # The USED_MODULES variable lists other modules used by the application.
-USED_MODULES = lib_dsp(>=6.0.0) lib_xs3_math(>=2.0.0)
+USED_MODULES = lib_dsp(>=6.0.0)
 
 # The XCORE_ARM_PROJECT variable, if set to 1, configures this
 # project to create both xCORE and ARM binaries.

--- a/examples/app_fft_xs3_math/src/main.xc
+++ b/examples/app_fft_xs3_math/src/main.xc
@@ -5,56 +5,41 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
+#include <string.h>
 
-#include "bfp_math.h"
-#include "dsp_bfp.h"
-
-#define LENGTH    (512)
+#include "dsp_fft_xs3.h"
 
 float sqr(float x) {return x*x;}
 
-void fft_float_mono_forward_512(float buffer[]) {
-  int exp = dsp_float_to_bfp(buffer, LENGTH/2);
+#define FFT_Main(op, nop, in, out, p) { \
+      fft_float_mono_forward_512(in);    \
+      memcpy(out, in, sizeof(float)*512); }
 
-  // Now call the three functions to do an FFT
-  xs3_fft_index_bit_reversal((buffer, complex_s32_t[]), LENGTH/2);
-  headroom_t hr = 2;
-  xs3_fft_dit_forward((buffer, complex_s32_t[]), LENGTH/2, &hr, &exp);
-  xs3_fft_mono_adjust((buffer, complex_s32_t[]), LENGTH, 0);
-
-  // And unpack back to floating point values
-  dsp_bfp_to_float(buffer, LENGTH/2, exp);
-}
-
-void fft_float_mono_inverse_512(float buffer[]) {
-  int exp = dsp_float_to_bfp(buffer, LENGTH/2);
-
-  xs3_fft_mono_adjust((buffer, complex_s32_t[]), LENGTH, 1);
-  xs3_fft_index_bit_reversal((buffer, complex_s32_t[]), LENGTH/2);
-  headroom_t hr = 2;
-  xs3_fft_dit_inverse((buffer, complex_s32_t[]), LENGTH/2, &hr, &exp);
-
-  dsp_bfp_to_float(buffer, LENGTH/2, exp);
-}
+#define IFFT_Main(op, nop, in, out, p) { \
+      fft_float_mono_inverse_512(in);    \
+      memcpy(out, in, sizeof(float)*512); }
 
 void fft_xs3_math() {
 int t0, t1, t2;
-  float buffer[LENGTH];
-  float flts[LENGTH];
+  float buffer1[FFT_LENGTH];
+  float buffer2[FFT_LENGTH];
+
+  float flts[FFT_LENGTH];
 
   // We'll just fill that vector with random mantissas.
-  for(int k = 0; k < LENGTH; k++){
-    flts[k] = buffer[k] = k*1000.0;//sin(k/4.0*3.1415926535)*100;
+  for(int k = 0; k < FFT_LENGTH; k++){
+    flts[k] = buffer1[k] = k*1000.0;//sin(k/4.0*3.1415926535)*100;
   }
 
   asm volatile("gettime %0" : "=r"(t0));
-  fft_float_mono_forward_512(buffer);
+  FFT_Main(0, 0, buffer1, buffer2, 0);
   asm volatile("gettime %0" : "=r"(t1));
-  fft_float_mono_inverse_512(buffer);
+  IFFT_Main(0, 0, buffer2, buffer1, 0);
+
   asm volatile("gettime %0" : "=r"(t2));
   float err = 0;
-  for(int k = 0; k < LENGTH; k++){
-    err += sqr(flts[k] - (buffer, float[])[k]);
+  for(int k = 0; k < FFT_LENGTH; k++){
+    err += sqr(flts[k] - (buffer1, float[])[k]);
   }
   printf("Error %g instructions: %d %d\n", err, (t1-t0)*6/5, (t2-t1)*6/5);
 }

--- a/lib_dsp/api/dsp_fft_xs3.h
+++ b/lib_dsp/api/dsp_fft_xs3.h
@@ -1,0 +1,32 @@
+// Copyright 2022 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#ifndef DSP_FFT_XS3_H_
+#define DSP_FFT_XS3_H_
+
+#include <stdint.h>
+
+#define FFT_LENGTH    (512)
+
+/** This function computes a forward FFT. The real input signal is
+ * supplied in an array of real floating-point values.
+ * The same array is also used to store the output.
+ * The number of points must be 512.
+ *
+ * \param[in,out] buffer   Array of float values.
+ */
+void fft_float_mono_forward_512 (
+                float buffer[] );
+
+
+/** This function computes an inverse FFT. The real input signal is
+ * supplied in an array of real floating-point values.
+ * The same array is also used to store the output.
+ * The number of points must be 512.
+ *
+ * \param[in,out] buffer   Array of float values.
+ */
+void fft_float_mono_inverse_512 (
+                float buffer[] );
+
+#endif

--- a/lib_dsp/module_build_info
+++ b/lib_dsp/module_build_info
@@ -1,6 +1,6 @@
 VERSION = 6.2.1
 
-DEPENDENT_MODULES = lib_logging(>=3.0.0)
+DEPENDENT_MODULES = lib_logging(>=3.0.0) lib_xs3_math(>=2.0.0)
 
 MODULE_XCC_FLAGS = $(XCC_FLAGS)
 

--- a/lib_dsp/src/fft/dsp_fft_xs3.xc
+++ b/lib_dsp/src/fft/dsp_fft_xs3.xc
@@ -1,0 +1,37 @@
+// Copyright 2022 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+#include <xs1.h>
+#include <xclib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <math.h>
+#include <string.h>
+
+#include "dsp_fft_xs3.h"
+#include "bfp_math.h"
+#include "dsp_bfp.h"
+
+void fft_float_mono_forward_512(float buffer[]) {
+  int exp = dsp_float_to_bfp(buffer, FFT_LENGTH/2);
+
+  // Now call the three functions to do an FFT
+  xs3_fft_index_bit_reversal((buffer, complex_s32_t[]), FFT_LENGTH/2);
+  headroom_t hr = 2;
+  xs3_fft_dit_forward((buffer, complex_s32_t[]), FFT_LENGTH/2, &hr, &exp);
+  xs3_fft_mono_adjust((buffer, complex_s32_t[]), FFT_LENGTH, 0);
+
+  // And unpack back to floating point values
+  dsp_bfp_to_float(buffer, FFT_LENGTH/2, exp);
+}
+
+void fft_float_mono_inverse_512(float buffer[]) {
+  int exp = dsp_float_to_bfp(buffer, FFT_LENGTH/2);
+
+  xs3_fft_mono_adjust((buffer, complex_s32_t[]), FFT_LENGTH, 1);
+  xs3_fft_index_bit_reversal((buffer, complex_s32_t[]), FFT_LENGTH/2);
+  headroom_t hr = 2;
+  xs3_fft_dit_inverse((buffer, complex_s32_t[]), FFT_LENGTH/2, &hr, &exp);
+
+  dsp_bfp_to_float(buffer, FFT_LENGTH/2, exp);
+}
+


### PR DESCRIPTION
The functions fft_float_mono_forward_512() and fft_float_mono_inverse_512() have been moved to lib_dsp. A brief description has been provided.

In app_fft_xs3_math I attempted to use macros to redefine the FFT functions used in the SHF BeClear lib:

```
/*============================================================================*
 *                                                                            *
 * Name          : FFT_Main                                                   *
 *                                                                            *
 * Description   : FFT (inplace possible) for real input data, using a        *
 *                 split-radix method.                                        *
 *                                                                            *
 * Pre           : op           : pointer to an object.                       *
 *                 nop          : Number of points (FFT size), power of 2.    *
 *                 in           : Array in[0..nop-1] of FLOAT.                *
 *                 out          : Array out[0..nop-1] of FLOAT.               *
 *                 p            : *p is correctly initialized.                *
 *                                                                            *
 * Post          : out          : FF format: the second                       *
 *                                half of the output of the FFT of real data  *
 *                                is the complex conjugate of the first half, *
 *                                and can thus be omitted.                    *
 *                                                                            *
 * Comments      :                                                            *
 *                                                                            *
 * Modifications :                                                            *
 *                                                                            *
 *============================================================================*/
void FFT_Main
(
    OBJStruct        * const op,
    const APES_SIZE_T        nop,
    const APES_FLOAT * const in,
          APES_FLOAT * const out,
    FFTstruct        * const p
);

/*============================================================================*
 *                                                                            *
 * Name          : IFFT_Main                                                  *
 *                                                                            *
 * Description   : Inverse FFT (inplace possible) for FF format input data,   *
 *                 using a split-radix method.                                *
 *                                                                            *
 * Pre           : op           : pointer to an object.                       *
 *                 nop          : Number of points (IFFT size), power of 2.   *
 *                 in           : Array in[0..nop-1] of FLOAT (in FF format). *
 *                 out          : Array out[0..nop-1] of FLOAT.               *
 *                 p            : *p is correctly initialized.                *
 *                                                                            *
 * Post          : out          : The IFFT is the reverse of FFT_Main.        *
 *                                                                            *
 * Comments      :                                                            *
 *                                                                            *
 * Modifications :                                                            *
 *                                                                            *
 *============================================================================*/
void IFFT_Main
(
    OBJStruct        * const op,
    const APES_SIZE_T        nop,
    const APES_FLOAT * const in,
          APES_FLOAT * const out,
    FFTstruct        * const p
);
```